### PR TITLE
Implement set error flag

### DIFF
--- a/components/ProposalActions.tsx
+++ b/components/ProposalActions.tsx
@@ -80,6 +80,7 @@ const ProposalActionsPanel = () => {
     governance &&
     proposalOwner &&
     wallet?.publicKey &&
+    proposalOwner?.account.governingTokenOwner.equals(wallet.publicKey) &&
     (proposal?.account.state === EnhancedProposalState.Succeeded ||
       proposal?.account.state === EnhancedProposalState.Executing ||
       proposal?.account.state === EnhancedProposalState.ExecutingWithErrors) &&
@@ -303,7 +304,6 @@ const ProposalActionsPanel = () => {
         {canSetFlagToExecutionError && (
           <Button
             tooltipMessage={setFlagToExecutionErrorTooltipContent}
-            className="w-1/2"
             onClick={handleSetExecutionErrorFlag}
             disabled={!connected}
           >

--- a/components/ProposalFilter.tsx
+++ b/components/ProposalFilter.tsx
@@ -19,7 +19,6 @@ const initialFilterSettings: Filters = {
   [EnhancedProposalState.Cancelled]: false,
   [EnhancedProposalState.Defeated]: true,
   [EnhancedProposalState.ExecutingWithErrors]: true,
-  [EnhancedProposalState.Outdated]: false,
 };
 
 const StyledAlertCount = styled.span`
@@ -156,15 +155,6 @@ const ProposalFilter = ({ filters, setFilters }) => {
                   checked={filterSettings[EnhancedProposalState.Succeeded]}
                   onChange={(checked) =>
                     handleFilters(EnhancedProposalState.Succeeded, checked)
-                  }
-                />
-              </div>
-              <div className="flex items-center justify-between pb-2">
-                Outdated
-                <Switch
-                  checked={filterSettings[EnhancedProposalState.Outdated]}
-                  onChange={(checked) =>
-                    handleFilters(EnhancedProposalState.Outdated, checked)
                   }
                 />
               </div>

--- a/components/ProposalStatusBadge.tsx
+++ b/components/ProposalStatusBadge.tsx
@@ -13,8 +13,6 @@ function getProposalStateLabel(
   switch (state) {
     case EnhancedProposalState.ExecutingWithErrors:
       return 'Execution Errors';
-    case EnhancedProposalState.Outdated:
-      return 'Outdated';
     case EnhancedProposalState.Voting:
       // If there is no tipping point and voting period ends then proposal stays in Voting state and needs to be manually finalized
       return hasVoteEnded ? 'Finalizing' : 'Voting';
@@ -45,10 +43,6 @@ function getProposalStateStyle(state: EnhancedProposalState) {
     state === EnhancedProposalState.ExecutingWithErrors
   ) {
     return 'border border-red text-red';
-  }
-
-  if (state === EnhancedProposalState.Outdated) {
-    return 'border border-orange text-orange';
   }
 
   return 'border border-fgd-3 text-fgd-3';

--- a/components/instructions/ExecuteAllInstructionButton.tsx
+++ b/components/instructions/ExecuteAllInstructionButton.tsx
@@ -95,7 +95,6 @@ export function ExecuteAllInstructionButton({
       EnhancedProposalState.Executing,
       EnhancedProposalState.ExecutingWithErrors,
       EnhancedProposalState.Succeeded,
-      EnhancedProposalState.Outdated,
     ].includes(proposal.account.state)
   ) {
     return null;

--- a/components/instructions/ExecuteInstructionButton.tsx
+++ b/components/instructions/ExecuteInstructionButton.tsx
@@ -127,8 +127,7 @@ export function ExecuteInstructionButton({
   if (
     proposal.account.state !== EnhancedProposalState.Executing &&
     proposal.account.state !== EnhancedProposalState.ExecutingWithErrors &&
-    proposal.account.state !== EnhancedProposalState.Succeeded &&
-    proposal.account.state !== EnhancedProposalState.Outdated
+    proposal.account.state !== EnhancedProposalState.Succeeded
   ) {
     return null;
   }

--- a/components/instructions/FlagInstructionErrorButton.tsx
+++ b/components/instructions/FlagInstructionErrorButton.tsx
@@ -3,6 +3,7 @@ import { flagInstructionError } from 'actions/flagInstructionError';
 import {
   InstructionExecutionStatus,
   Proposal,
+  ProposalState,
   ProposalTransaction,
   TokenOwnerRecord,
 } from '@solana/spl-governance';
@@ -34,6 +35,7 @@ export function FlagInstructionErrorButton({
   const connection = useWalletStore((s) => s.connection);
 
   if (
+    proposal.account.state === ProposalState.ExecutingWithErrors ||
     playState !== PlayState.Error ||
     proposalInstruction.account.executionStatus !==
       InstructionExecutionStatus.Error ||

--- a/components/instructions/instructionCard.tsx
+++ b/components/instructions/instructionCard.tsx
@@ -3,6 +3,7 @@ import { ExternalLinkIcon } from '@heroicons/react/outline';
 import {
   AccountMetaData,
   Proposal,
+  ProposalState,
   ProposalTransaction,
 } from '@solana/spl-governance';
 import {
@@ -169,10 +170,12 @@ export default function InstructionCard({
           ></img>
         )}
       </h3>
+
       <InstructionProgram
         endpoint={connection.endpoint}
         programId={proposalInstruction.account.getSingleInstruction().programId}
-      ></InstructionProgram>
+      />
+
       <div className="border-b border-bkg-4 mb-6">
         {proposalInstruction.account
           .getSingleInstruction()
@@ -202,7 +205,7 @@ export default function InstructionCard({
           <img src={nftImgUrl}></img>
         </div>
       ) : (
-        <InstructionData descriptor={descriptor}></InstructionData>
+        <InstructionData descriptor={descriptor} />
       )}
 
       {
@@ -236,7 +239,8 @@ export default function InstructionCard({
           proposalInstruction={proposalInstruction}
         />
 
-        {proposal && (
+        {proposal &&
+        proposal.account.state !== ProposalState.ExecutingWithErrors ? (
           <ExecuteInstructionButton
             disabled={
               isInstructionAboutOrcaWhirlpoolOpenPosition && !additionalSigner
@@ -247,7 +251,7 @@ export default function InstructionCard({
             setPlaying={setPlaying}
             additionalSigner={additionalSigner ?? undefined}
           />
-        )}
+        ) : null}
       </div>
     </div>
   );

--- a/components/instructions/instructionPanel.tsx
+++ b/components/instructions/instructionPanel.tsx
@@ -4,7 +4,7 @@ import { Disclosure } from '@headlessui/react';
 import { ChevronDownIcon } from '@heroicons/react/solid';
 import { useEffect, useRef, useState } from 'react';
 import useWalletStore from 'stores/useWalletStore';
-import { RpcContext } from '@solana/spl-governance';
+import { ProposalState, RpcContext } from '@solana/spl-governance';
 import useRealm from '@hooks/useRealm';
 import { getProgramVersionForRealm } from '@models/registry/api';
 import {
@@ -104,7 +104,9 @@ export function InstructionPanel() {
                 </div>
               ))}
 
-              {proposal && proposalInstructions.length > 1 && (
+              {proposal &&
+              proposalInstructions.length > 1 &&
+              proposal.account.state !== ProposalState.ExecutingWithErrors ? (
                 <div className="flex justify-end">
                   <ExecuteAllInstructionButton
                     proposal={proposal}
@@ -113,7 +115,7 @@ export function InstructionPanel() {
                     setPlaying={setPlaying}
                   />
                 </div>
-              )}
+              ) : null}
             </Disclosure.Panel>
           </>
         )}

--- a/pages/dao/[symbol]/proposal/[pk].tsx
+++ b/pages/dao/[symbol]/proposal/[pk].tsx
@@ -40,8 +40,7 @@ const Proposal = () => {
     (proposal.account.state === EnhancedProposalState.Completed ||
       proposal.account.state === EnhancedProposalState.Executing ||
       proposal.account.state === EnhancedProposalState.SigningOff ||
-      proposal.account.state === EnhancedProposalState.Succeeded ||
-      proposal.account.state === EnhancedProposalState.Outdated);
+      proposal.account.state === EnhancedProposalState.Succeeded);
 
   useEffect(() => {
     const handleResolveDescription = async () => {

--- a/pages/dao/[symbol]/proposal/components/MyProposalsBtn.tsx
+++ b/pages/dao/[symbol]/proposal/components/MyProposalsBtn.tsx
@@ -74,7 +74,6 @@ const MyProposalsBn = () => {
   const unReleased = myProposals.filter(
     (x) =>
       (x.account.state === EnhancedProposalState.Succeeded ||
-        x.account.state === EnhancedProposalState.Outdated ||
         x.account.state === EnhancedProposalState.Completed) &&
       x.account.isVoteFinalized() &&
       !ownVoteRecordsByProposal[x.pubkey.toBase58()]?.account.isRelinquished,


### PR DESCRIPTION
Allow the owner of the proposal to set an error execution flag when proposal is in state: succeed, execute.
Remove the _Outdated_ custom flag.


Example of transaction to set error flag on proposal:
https://explorer.solana.com/tx/5MZVBfHCNP2GoreWQzwEqs6bdy1YLYtWGGJKY8BPB26ZjUH8cJRn2Tbt2A1rm4oF6AK2VeFmXbzZqFw2VbY7Cwww

Proposal:
https://governance.uxd.fi/dao/9eoHFq35i7SMif7zCn53nVpQz5kwXyqNuuif2U7VGyqp/proposal/Ei1DrJtdFKJx7td4q2gnBKEbi3wY3ub9PTCxep7QqFBN

<img width="740" alt="Screenshot 2022-07-21 at 16 28 37" src="https://user-images.githubusercontent.com/22965416/180213516-bb7c8386-5a3e-41d2-aa91-60c39a4ecaeb.png">

