### PR TITLE
fix(quarry): fix itx name display for quarry claim reward

### DIFF
--- a/components/instructions/programs/quarry.tsx
+++ b/components/instructions/programs/quarry.tsx
@@ -124,7 +124,7 @@ export const QUARRY_MINE_PROGRAM_INSTRUCTIONS = {
     },
 
     [quarryMineConfiguration.quarryMineProgramInstructions.claimRewards]: {
-      name: 'Quarry Mine - Create Miner',
+      name: 'Quarry Mine - Claim Rewards',
       accounts: [
         'Mint Wrapper',
         'Mint Wrapper Program',


### PR DESCRIPTION
Not sure whether it's possible to get the amount of rewards accurately